### PR TITLE
Save username and access token to keychain during registration

### DIFF
--- a/NewDawn/NewDawn/RegisterUserViewController.swift
+++ b/NewDawn/NewDawn/RegisterUserViewController.swift
@@ -7,7 +7,7 @@
 //
 
 import UIKit
-
+import SwiftKeychainWrapper
 class RegisterUserViewController: UIViewController {
 
     @IBOutlet weak var firstNameTextField: UITextField!
@@ -90,6 +90,28 @@ class RegisterUserViewController: UIViewController {
     }
     
     func readRegisterResponse(parseJSON: NSDictionary) -> Void {
+        let userName = parseJSON["username"] as? String
+        let accessToken = parseJSON["token"] as? String
+        if userName?.isEmpty == true || accessToken?.isEmpty == true {
+            print("Cannot receive username and access token")
+        }
+        // This access token is required with requests to get sensitive/private data
+        print("Username: \(String(describing: userName))")
+        print("Access token: \(String(describing: accessToken))")
+        let saveUserName: Bool = KeychainWrapper.standard.set(userName!, forKey: "userName")
+        let saveAccessToken: Bool = KeychainWrapper.standard.set(accessToken!, forKey: "accessToken")
+        print("Username Saved to Keychain: \(saveUserName)")
+        print("Access token Saved to Keychain: \(saveAccessToken)")
+        if (userName?.isEmpty)!
+        {
+            self.displayMessage(userMessage: "No Username Found")
+            return
+        }
+        if (accessToken?.isEmpty)!
+        {
+            self.displayMessage(userMessage: "No Access Token Found")
+            return
+        }
         // Go to profile page
         DispatchQueue.main.async {
             let profilePage = self.storyboard?.instantiateViewController(withIdentifier: "ProfileViewController")


### PR DESCRIPTION
Right after the user is registered, we store username and access token into keychain
Test to register a new account, and the access token is generated and is able to be used in request profile (although the profile doesn't have any info yet
![screen shot 2018-12-08 at 5 51 40 pm](https://user-images.githubusercontent.com/8229754/49691519-f2200280-fb11-11e8-9fac-5157fe298dc6.png)
)